### PR TITLE
Proper `time` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "htp"
 version = "0.4.2"
 authors = ["PicoJr <picojr_dev@gmx.com>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/PicoJr/htp"
 description = "human time parser"
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "examples"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pest = "2.0"
-pest_derive = "2.0"
-thiserror = "1.0.20"
-chrono = { version = "0.4.12", optional = true }
+pest = "2.4"
+pest_derive = "2.4"
+thiserror = "1.0.37"
+chrono = { version = "0.4.23", optional = true }
 time = { version = "0.3.17", optional = true, features = ["parsing", "macros"] }
 
 # https://github.com/rust-lang/rust/issues/88791
@@ -24,7 +24,7 @@ time = { version = "0.3.17", optional = true, features = ["parsing", "macros"] }
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [features]
-default = ["chrono"]
+default = ["chrono", "time"]
 chrono = ["dep:chrono"]
 time = ["dep:time"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,18 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "examples"]
 pest = "2.0"
 pest_derive = "2.0"
 thiserror = "1.0.20"
-chrono = "0.4.12"
+chrono = { version = "0.4.12", optional = true }
+time = { version = "0.3.17", optional = true, features = ["parsing", "macros"] }
 
 # https://github.com/rust-lang/rust/issues/88791
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+
+[features]
+default = ["chrono"]
+chrono = ["dep:chrono"]
+time = ["dep:time"]
+
+[[example]]
+name = "time_parser"
+path = "examples/time_parser.rs"

--- a/examples/time_parser.rs
+++ b/examples/time_parser.rs
@@ -1,11 +1,19 @@
-use chrono::Local;
 use std::env;
 use std::error::Error;
+
+#[cfg(feature = "chrono")]
+use chrono::Utc;
+#[cfg(feature = "time")]
+use time::OffsetDateTime;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let parameters = &args[1..];
-    let datetime = htp::parse(&parameters.join(" "), Local::now());
+    #[cfg(feature = "time")]
+    let datetime = htp::parse(&parameters.join(" "), OffsetDateTime::now_utc());
+    #[cfg(feature = "chrono")]
+    let datetime = htp::parse(&parameters.join(" "), Utc::now());
+
     match datetime {
         Ok(datetime) => println!("{:?}", datetime),
         Err(e) => println!("{}", e),

--- a/examples/time_parser.rs
+++ b/examples/time_parser.rs
@@ -1,22 +1,26 @@
 use std::env;
 use std::error::Error;
 
-#[cfg(feature = "chrono")]
 use chrono::Utc;
-#[cfg(feature = "time")]
 use time::OffsetDateTime;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let parameters = &args[1..];
-    #[cfg(feature = "time")]
-    let datetime = htp::parse(&parameters.join(" "), OffsetDateTime::now_utc());
-    #[cfg(feature = "chrono")]
-    let datetime = htp::parse(&parameters.join(" "), Utc::now());
 
-    match datetime {
-        Ok(datetime) => println!("{:?}", datetime),
-        Err(e) => println!("{}", e),
+    let time_result = htp::parse(&parameters.join(" "), OffsetDateTime::now_utc());
+
+    match time_result {
+        Ok(datetime) => println!("time: {}", datetime),
+        Err(e) => println!("time: {}", e),
     }
+
+    let chrono_result = htp::parse(&parameters.join(" "), Utc::now());
+
+    match chrono_result {
+        Ok(datetime) => println!("chrono: {}", datetime),
+        Err(e) => println!("chrono: {}", e),
+    }
+
     Ok(())
 }

--- a/examples/time_parser.rs
+++ b/examples/time_parser.rs
@@ -1,25 +1,33 @@
 use std::env;
 use std::error::Error;
 
+#[cfg(feature = "chrono")]
 use chrono::Utc;
+#[cfg(feature = "time")]
 use time::OffsetDateTime;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let parameters = &args[1..];
 
-    let time_result = htp::parse(&parameters.join(" "), OffsetDateTime::now_utc());
+    #[cfg(feature = "time")]
+    {
+        let time_result = htp::parse(&parameters.join(" "), OffsetDateTime::now_utc());
 
-    match time_result {
-        Ok(datetime) => println!("time: {}", datetime),
-        Err(e) => println!("time: {}", e),
+        match time_result {
+            Ok(datetime) => println!("time: {}", datetime),
+            Err(e) => println!("time: {}", e),
+        }
     }
 
-    let chrono_result = htp::parse(&parameters.join(" "), Utc::now());
+    #[cfg(feature = "chrono")]
+    {
+        let chrono_result = htp::parse(&parameters.join(" "), Utc::now());
 
-    match chrono_result {
-        Ok(datetime) => println!("chrono: {}", datetime),
-        Err(e) => println!("chrono: {}", e),
+        match chrono_result {
+            Ok(datetime) => println!("chrono: {}", datetime),
+            Err(e) => println!("chrono: {}", e),
+        }
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,21 +3,38 @@
 //!
 //! ## Example
 //!
-//! ```
-//! use chrono::{Utc, TimeZone};
+//! ```rust
 //! use htp::parse;
-//! let now = Utc.datetime_from_str("2020-12-24T23:45:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-//! let expected = Utc.datetime_from_str("2020-12-18T19:43:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-//! let datetime = parse("last friday at 19:43", now).unwrap();
-//! assert_eq!(datetime, expected);
+//!
+//! // using `time`
+//! #[cfg(feature = "time")]
+//! {
+//!     use time::{PrimitiveDateTime, macros::format_description};
+//!     
+//!     let now = PrimitiveDateTime::parse("2020-12-24T23:45:00", format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]")).unwrap().assume_utc();
+//!     let expected = PrimitiveDateTime::parse("2020-12-18T19:43:00", format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]")).unwrap().assume_utc();
+//!     let datetime = parse("last friday at 19:43", now).unwrap();
+//!     assert_eq!(datetime, expected);
+//! }
+//!
+//! // using `chrono`
+//! #[cfg(feature = "chrono")]
+//! {
+//!     use chrono::{Utc, TimeZone};
+//!
+//!     let now = Utc.datetime_from_str("2020-12-24T23:45:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+//!     let expected = Utc.datetime_from_str("2020-12-18T19:43:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+//!     let datetime = parse("last friday at 19:43", now).unwrap();
+//!     assert_eq!(datetime, expected);
+//! }
 //! ```
 //!
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
 
+#[cfg(feature = "chrono")]
 use chrono::DateTime;
 use thiserror::Error;
+#[cfg(feature = "time")]
+use time::OffsetDateTime;
 
 pub mod interpreter;
 pub mod parser;
@@ -33,7 +50,16 @@ pub enum HTPError {
 /// Same as `parse_time_clue(s, now, false)`
 ///
 /// Parse time clue from `s` given reference time `now` in timezone `Tz`.
+#[cfg(feature = "chrono")]
 pub fn parse<Tz: chrono::TimeZone>(s: &str, now: DateTime<Tz>) -> Result<DateTime<Tz>, HTPError> {
+    parse_time_clue(s, now, false)
+}
+
+/// Same as `parse_time_clue(s, now, false)`
+///
+/// Parse time clue from `s` given reference time `now` in timezone `Tz`.
+#[cfg(feature = "time")]
+pub fn parse(s: &str, now: OffsetDateTime) -> Result<OffsetDateTime, HTPError> {
     parse_time_clue(s, now, false)
 }
 
@@ -43,11 +69,29 @@ pub fn parse<Tz: chrono::TimeZone>(s: &str, now: DateTime<Tz>) -> Result<DateTim
 /// * if true: times without a day will be interpreted as times during the following the day.
 /// e.g. 19:43 will be interpreted as tomorrow at 19:43 if current time is > 19:43.
 /// * if false: times without a day will be interpreted as times during current day.
+#[cfg(feature = "chrono")]
 pub fn parse_time_clue<Tz: chrono::TimeZone>(
     s: &str,
     now: DateTime<Tz>,
     assume_next_day: bool,
 ) -> Result<DateTime<Tz>, HTPError> {
+    let time_clue = parser::parse_time_clue_from_str(s)?;
+    let datetime = interpreter::evaluate_time_clue(time_clue, now, assume_next_day)?;
+    Ok(datetime)
+}
+
+/// Parse time clue from `s` given reference time `now` in timezone `Tz`.
+///
+/// `assume_next_day`:
+/// * if true: times without a day will be interpreted as times during the following the day.
+/// e.g. 19:43 will be interpreted as tomorrow at 19:43 if current time is > 19:43.
+/// * if false: times without a day will be interpreted as times during current day.
+#[cfg(feature = "time")]
+pub fn parse_time_clue(
+    s: &str,
+    now: OffsetDateTime,
+    assume_next_day: bool,
+) -> Result<OffsetDateTime, HTPError> {
     let time_clue = parser::parse_time_clue_from_str(s)?;
     let datetime = interpreter::evaluate_time_clue(time_clue, now, assume_next_day)?;
     Ok(datetime)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -420,7 +420,8 @@ mod test {
     }
 
     #[test]
-    fn test_parse_relative_day_ok() {
+    #[cfg(feature = "time")]
+    fn time_test_parse_relative_day_ok() {
         assert_eq!(TimeClue::Now, parse_time_clue_from_str("now").unwrap());
         assert_eq!(
             TimeClue::SameWeekDayAt(TimeWeekday::Friday.into(), Some((19, 43, 0)), None),
@@ -442,6 +443,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "chrono")]
     fn chrono_test_parse_same_week_ok() {
         let weekdays = vec![
             (ChronoWeekday::Mon, "monday"),
@@ -480,6 +482,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "time")]
     fn time_test_parse_same_week_ok() {
         let weekdays = vec![
             (TimeWeekday::Monday, "monday"),

--- a/src/unified.rs
+++ b/src/unified.rs
@@ -11,6 +11,7 @@ use chrono::{Datelike, TimeZone, Timelike};
 use time::UtcOffset;
 
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum DateTime {
     #[cfg(feature = "time")]
     Time(time::OffsetDateTime),

--- a/src/unified.rs
+++ b/src/unified.rs
@@ -1,24 +1,29 @@
 use std::{
     cmp::Ordering,
-    convert::TryFrom,
     fmt,
     ops::{Add, Sub},
     time::Duration,
 };
 
+#[cfg(feature = "chrono")]
 use chrono::{Datelike, TimeZone, Timelike};
+#[cfg(feature = "time")]
 use time::UtcOffset;
 
 #[derive(Debug, Clone, Copy)]
 pub enum DateTime {
+    #[cfg(feature = "time")]
     Time(time::OffsetDateTime),
+    #[cfg(feature = "chrono")]
     Chrono(chrono::DateTime<chrono::Utc>),
 }
 
 impl fmt::Display for DateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(t) => write!(f, "{}", t),
+            #[cfg(feature = "chrono")]
             Self::Chrono(t) => write!(f, "{}", t),
         }
     }
@@ -29,7 +34,9 @@ impl Add<Duration> for DateTime {
 
     fn add(self, rhs: Duration) -> Self::Output {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(t) => Self::Time(t + rhs),
+            #[cfg(feature = "chrono")]
             Self::Chrono(t) => Self::Chrono(t + chrono::Duration::from_std(rhs).unwrap()), // chrono wants to be a unique one
         }
     }
@@ -40,16 +47,21 @@ impl Sub<Duration> for DateTime {
 
     fn sub(self, rhs: Duration) -> Self::Output {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(t) => Self::Time(t - rhs),
+            #[cfg(feature = "chrono")]
             Self::Chrono(t) => Self::Chrono(t - chrono::Duration::from_std(rhs).unwrap()), // chrono wants to be a unique one
         }
     }
 }
 
 impl PartialOrd for DateTime {
+    #[allow(unreachable_patterns)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
+            #[cfg(feature = "time")]
             (Self::Time(a), Self::Time(b)) => a.partial_cmp(b),
+            #[cfg(feature = "chrono")]
             (Self::Chrono(a), Self::Chrono(b)) => a.partial_cmp(b),
             _ => unimplemented!("Cannot compare time::OffsetDateTime with chrono::DateTime"),
         }
@@ -57,9 +69,12 @@ impl PartialOrd for DateTime {
 }
 
 impl PartialEq for DateTime {
+    #[allow(unreachable_patterns)]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            #[cfg(feature = "time")]
             (Self::Time(self_time), Self::Time(other_time)) => self_time == other_time,
+            #[cfg(feature = "chrono")]
             (Self::Chrono(self_chrono), Self::Chrono(other_chrono)) => self_chrono == other_chrono,
             _ => unimplemented!("Cannot compare time::OffsetDateTime with chrono::DateTime"),
         }
@@ -67,15 +82,21 @@ impl PartialEq for DateTime {
 }
 
 impl DateTime {
+    #[cfg(feature = "time")]
+    #[allow(clippy::unnecessary_wraps)]
     pub const fn as_time(self) -> Option<time::OffsetDateTime> {
         match self {
             Self::Time(t) => Some(t),
+            #[cfg(feature = "chrono")]
             Self::Chrono(_) => None,
         }
     }
 
+    #[cfg(feature = "chrono")]
+    #[allow(clippy::unnecessary_wraps)]
     pub const fn as_chrono(self) -> Option<chrono::DateTime<chrono::Utc>> {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(_) => None,
             Self::Chrono(t) => Some(t),
         }
@@ -83,16 +104,20 @@ impl DateTime {
 
     pub fn weekday(&self) -> Weekday {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(t) => t.weekday().into(),
+            #[cfg(feature = "chrono")]
             Self::Chrono(t) => t.weekday().into(),
         }
     }
 
     pub fn and_hms(&self, hour: u8, min: u8, sec: u8) -> Self {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(t) => Self::Time(
                 t.replace_time(time::Time::from_hms(hour, min, sec).expect("invalid time")),
             ),
+            #[cfg(feature = "chrono")]
             Self::Chrono(t) => Self::Chrono(
                 t.with_hour(u32::from(hour))
                     .expect("invalid hour")
@@ -106,6 +131,7 @@ impl DateTime {
 
     pub fn and_ymd(&self, year: i32, month: u8, day: u8) -> Self {
         match self {
+            #[cfg(feature = "time")]
             Self::Time(t) => Self::Time(
                 t.replace_date(
                     time::Date::from_calendar_date(
@@ -116,6 +142,7 @@ impl DateTime {
                     .expect("invalid date"),
                 ),
             ),
+            #[cfg(feature = "chrono")]
             Self::Chrono(t) => Self::Chrono(
                 t.with_year(year)
                     .expect("invalid year")
@@ -128,12 +155,14 @@ impl DateTime {
     }
 }
 
+#[cfg(feature = "time")]
 impl From<time::OffsetDateTime> for DateTime {
     fn from(t: time::OffsetDateTime) -> Self {
         Self::Time(t.replace_offset(UtcOffset::UTC))
     }
 }
 
+#[cfg(feature = "chrono")]
 impl<T: TimeZone> From<chrono::DateTime<T>> for DateTime {
     fn from(t: chrono::DateTime<T>) -> Self {
         Self::Chrono(t.with_timezone(&chrono::Utc))
@@ -157,6 +186,7 @@ impl Weekday {
     }
 }
 
+#[cfg(feature = "chrono")]
 impl From<chrono::Weekday> for Weekday {
     fn from(weekday: chrono::Weekday) -> Self {
         match weekday {
@@ -171,6 +201,7 @@ impl From<chrono::Weekday> for Weekday {
     }
 }
 
+#[cfg(feature = "time")]
 impl From<time::Weekday> for Weekday {
     fn from(weekday: time::Weekday) -> Self {
         match weekday {

--- a/src/unified.rs
+++ b/src/unified.rs
@@ -1,0 +1,186 @@
+use std::{
+    cmp::Ordering,
+    convert::TryFrom,
+    fmt,
+    ops::{Add, Sub},
+    time::Duration,
+};
+
+use chrono::{Datelike, TimeZone, Timelike};
+use time::UtcOffset;
+
+#[derive(Debug, Clone, Copy)]
+pub enum DateTime {
+    Time(time::OffsetDateTime),
+    Chrono(chrono::DateTime<chrono::Utc>),
+}
+
+impl fmt::Display for DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Time(t) => write!(f, "{}", t),
+            Self::Chrono(t) => write!(f, "{}", t),
+        }
+    }
+}
+
+impl Add<Duration> for DateTime {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        match self {
+            Self::Time(t) => Self::Time(t + rhs),
+            Self::Chrono(t) => Self::Chrono(t + chrono::Duration::from_std(rhs).unwrap()), // chrono wants to be a unique one
+        }
+    }
+}
+
+impl Sub<Duration> for DateTime {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        match self {
+            Self::Time(t) => Self::Time(t - rhs),
+            Self::Chrono(t) => Self::Chrono(t - chrono::Duration::from_std(rhs).unwrap()), // chrono wants to be a unique one
+        }
+    }
+}
+
+impl PartialOrd for DateTime {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (Self::Time(a), Self::Time(b)) => a.partial_cmp(b),
+            (Self::Chrono(a), Self::Chrono(b)) => a.partial_cmp(b),
+            _ => unimplemented!("Cannot compare time::OffsetDateTime with chrono::DateTime"),
+        }
+    }
+}
+
+impl PartialEq for DateTime {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Time(self_time), Self::Time(other_time)) => self_time == other_time,
+            (Self::Chrono(self_chrono), Self::Chrono(other_chrono)) => self_chrono == other_chrono,
+            _ => unimplemented!("Cannot compare time::OffsetDateTime with chrono::DateTime"),
+        }
+    }
+}
+
+impl DateTime {
+    pub const fn as_time(self) -> Option<time::OffsetDateTime> {
+        match self {
+            Self::Time(t) => Some(t),
+            Self::Chrono(_) => None,
+        }
+    }
+
+    pub const fn as_chrono(self) -> Option<chrono::DateTime<chrono::Utc>> {
+        match self {
+            Self::Time(_) => None,
+            Self::Chrono(t) => Some(t),
+        }
+    }
+
+    pub fn weekday(&self) -> Weekday {
+        match self {
+            Self::Time(t) => t.weekday().into(),
+            Self::Chrono(t) => t.weekday().into(),
+        }
+    }
+
+    pub fn and_hms(&self, hour: u8, min: u8, sec: u8) -> Self {
+        match self {
+            Self::Time(t) => Self::Time(
+                t.replace_time(time::Time::from_hms(hour, min, sec).expect("invalid time")),
+            ),
+            Self::Chrono(t) => Self::Chrono(
+                t.with_hour(u32::from(hour))
+                    .expect("invalid hour")
+                    .with_minute(u32::from(min))
+                    .expect("invalid minute")
+                    .with_second(u32::from(sec))
+                    .expect("invalid second"),
+            ),
+        }
+    }
+
+    pub fn and_ymd(&self, year: i32, month: u8, day: u8) -> Self {
+        match self {
+            Self::Time(t) => Self::Time(
+                t.replace_date(
+                    time::Date::from_calendar_date(
+                        year,
+                        time::Month::try_from(month).expect("invalid month"),
+                        day,
+                    )
+                    .expect("invalid date"),
+                ),
+            ),
+            Self::Chrono(t) => Self::Chrono(
+                t.with_year(year)
+                    .expect("invalid year")
+                    .with_month(u32::from(month))
+                    .expect("invalid month")
+                    .with_day(u32::from(day))
+                    .expect("invalid day"),
+            ),
+        }
+    }
+}
+
+impl From<time::OffsetDateTime> for DateTime {
+    fn from(t: time::OffsetDateTime) -> Self {
+        Self::Time(t.replace_offset(UtcOffset::UTC))
+    }
+}
+
+impl<T: TimeZone> From<chrono::DateTime<T>> for DateTime {
+    fn from(t: chrono::DateTime<T>) -> Self {
+        Self::Chrono(t.with_timezone(&chrono::Utc))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Weekday {
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
+}
+
+impl Weekday {
+    pub const fn num_days_from_monday(self) -> u8 {
+        self as _
+    }
+}
+
+impl From<chrono::Weekday> for Weekday {
+    fn from(weekday: chrono::Weekday) -> Self {
+        match weekday {
+            chrono::Weekday::Mon => Self::Monday,
+            chrono::Weekday::Tue => Self::Tuesday,
+            chrono::Weekday::Wed => Self::Wednesday,
+            chrono::Weekday::Thu => Self::Thursday,
+            chrono::Weekday::Fri => Self::Friday,
+            chrono::Weekday::Sat => Self::Saturday,
+            chrono::Weekday::Sun => Self::Sunday,
+        }
+    }
+}
+
+impl From<time::Weekday> for Weekday {
+    fn from(weekday: time::Weekday) -> Self {
+        match weekday {
+            time::Weekday::Monday => Self::Monday,
+            time::Weekday::Tuesday => Self::Tuesday,
+            time::Weekday::Wednesday => Self::Wednesday,
+            time::Weekday::Thursday => Self::Thursday,
+            time::Weekday::Friday => Self::Friday,
+            time::Weekday::Saturday => Self::Saturday,
+            time::Weekday::Sunday => Self::Sunday,
+        }
+    }
+}


### PR DESCRIPTION
- All tests pass, example works (as far as I can tell)
- Added `chrono` and `time` features, both enabled by default
- Added support for `time` crate

It's rather hacky, but it seems to work just fine.