### PR TITLE
fix: removed `oldtime` feature from chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "examples"]
 pest = "2.0"
 pest_derive = "2.0"
 thiserror = "1.0.20"
-chrono = "0.4.12"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 
 # https://github.com/rust-lang/rust/issues/88791
 [package.metadata.docs.rs]


### PR DESCRIPTION
Reason:
https://github.com/chronotope/chrono/issues/553